### PR TITLE
Fix ElvargClient Java 17 compatibility

### DIFF
--- a/ElvargClient/build.gradle.kts
+++ b/ElvargClient/build.gradle.kts
@@ -21,7 +21,14 @@ dependencies {
 group = "Elvarg"
 version = "1.0-SNAPSHOT"
 description = "Elvarg-Game-Client"
-java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.sourceCompatibility = JavaVersion.VERSION_17
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.addAll(listOf(
+        "-Xlint:-removal",
+        "-Xlint:-deprecation"
+    ))
+}
 
 application {
     mainClass.set("com.runescape.GameWindow")

--- a/ElvargClient/src/main/java/com/runescape/graphics/Slider.java
+++ b/ElvargClient/src/main/java/com/runescape/graphics/Slider.java
@@ -5,7 +5,6 @@ import com.runescape.Configuration;
 import com.runescape.graphics.sprite.Sprite;
 import com.runescape.graphics.widget.Widget;
 import com.runescape.draw.Rasterizer3D;
-import jdk.nashorn.internal.runtime.regexp.joni.Config;
 
 public class Slider {
 


### PR DESCRIPTION
- Update build.gradle.kts to use Java 17 instead of Java 8
- Remove unused import causing compilation error in Slider.java
- Suppress deprecation warnings for legacy Applet code
- Enable successful build and run with modern Java versions

🤖 Generated with [Claude Code](https://claude.ai/code)